### PR TITLE
Refactor failing unit test a little

### DIFF
--- a/src/Notifier.cpp
+++ b/src/Notifier.cpp
@@ -31,8 +31,7 @@ Notifier::Notifier(const std::string& notifierQueue, const std::string& handshak
    : mNotifierQueueName(notifierQueue),
      mHandshakeQueueName(handshakeQueue),
      mMaxTimeoutInSec(maxTimeoutInSec),
-     mGetShotTimeoutInMs(maxGetShotTimeoutInMs),
-     mKeepRunning{true} {};
+     mGetShotTimeoutInMs(maxGetShotTimeoutInMs) {};
 
 Notifier::~Notifier() {
    Reset();
@@ -68,13 +67,11 @@ bool Notifier::Initialize(const size_t handshakeCount) {
  */
 std::string Notifier::ReceiveData() {
    StopWatch waitCheck;
-   while (waitCheck.ElapsedSec() < mMaxTimeoutInSec && !zctx_interrupted && mKeepRunning.load()) {
-      std::string msg;
-      if (!zctx_interrupted && mHandshakeQueue.get() != nullptr && mHandshakeQueue->GetShot(msg, mGetShotTimeoutInMs)) {         
-         return msg;
-      }
+   std::string msg = "";
+   while (waitCheck.ElapsedSec() < mMaxTimeoutInSec && !zctx_interrupted && msg == "") {
+      mHandshakeQueue->GetShot(msg, mGetShotTimeoutInMs);
    }
-   return "";
+   return msg;
 }
    
 /*
@@ -182,7 +179,6 @@ size_t Notifier::ReceiveConfirmation() {
 void Notifier::Reset() {
    mQueue.reset(nullptr);
    mHandshakeQueue.reset(nullptr);
-   mKeepRunning.store(false);
 }
 
 /*

--- a/src/Notifier.h
+++ b/src/Notifier.h
@@ -45,5 +45,4 @@ class Notifier {
    const size_t mMaxTimeoutInSec;
    const int mGetShotTimeoutInMs;
    std::string mNotifyMessage = "notify";
-   std::atomic<bool> mKeepRunning;
 };

--- a/src/Rifle.cpp
+++ b/src/Rifle.cpp
@@ -1,6 +1,5 @@
 #define _OPEN_SYS
 #include <sys/stat.h>
-#include <iostream>
 #include "Rifle.h"
 #include "czmq.h"
 #include "g3log/g3log.hpp"
@@ -151,12 +150,10 @@ bool Rifle::Fire(const std::string& bullet, const int waitToFire) {
    //LOG(DEBUG) << "RifleFire";
    if (!mChamber) {
       LOG(WARNING) << "Socket uninitialized!";
-      std::cout << "Failing 1" << std::endl;
       return false;
    }
    if (bullet.empty()) {
       LOG(WARNING) << "Tried to send empty packet";
-      std::cout << "Failing 2" << std::endl;
       return false;
    }
    zmq_pollitem_t items [] = {
@@ -170,12 +167,10 @@ bool Rifle::Fire(const std::string& bullet, const int waitToFire) {
          return CZMQToolkit::SendExistingMessage(message, mChamber);
       } else {
          LOG(WARNING) << "Error on Zmq socket send: " << zmq_strerror(zmq_errno());
-         std::cout << "Failing 3" << std::endl;
          return false;
       }
    } else {
       //      LOG(WARNING) << "timeout in zmq_pollout " << GetBinding();
-      std::cout << "Failing 4" << std::endl;
       return false;
    }
 }

--- a/src/Rifle.cpp
+++ b/src/Rifle.cpp
@@ -1,6 +1,6 @@
 #define _OPEN_SYS
 #include <sys/stat.h>
-
+#include <iostream>
 #include "Rifle.h"
 #include "czmq.h"
 #include "g3log/g3log.hpp"
@@ -151,10 +151,12 @@ bool Rifle::Fire(const std::string& bullet, const int waitToFire) {
    //LOG(DEBUG) << "RifleFire";
    if (!mChamber) {
       LOG(WARNING) << "Socket uninitialized!";
+      std::cout << "Failing 1" << std::endl;
       return false;
    }
    if (bullet.empty()) {
       LOG(WARNING) << "Tried to send empty packet";
+      std::cout << "Failing 2" << std::endl;
       return false;
    }
    zmq_pollitem_t items [] = {
@@ -168,10 +170,12 @@ bool Rifle::Fire(const std::string& bullet, const int waitToFire) {
          return CZMQToolkit::SendExistingMessage(message, mChamber);
       } else {
          LOG(WARNING) << "Error on Zmq socket send: " << zmq_strerror(zmq_errno());
+         std::cout << "Failing 3" << std::endl;
          return false;
       }
    } else {
       //      LOG(WARNING) << "timeout in zmq_pollout " << GetBinding();
+      std::cout << "Failing 4" << std::endl;
       return false;
    }
 }

--- a/test/NotifierTest.cpp
+++ b/test/NotifierTest.cpp
@@ -151,7 +151,6 @@ namespace {
       while (ParentHasNotSentExitSignal(receiverThreadData)) {
          received = notifier->ReceiveData();
          if (!received.empty()) {
-            std::cout << "receiver got something hooray: " << received << std::endl;
             EXPECT_EQ(received, toReceive);
             UpdateThreadDataAfterReceivingMessage(receiverThreadData);
             break; // Needed, so that received doesn't get overwritten on next iteration
@@ -458,7 +457,6 @@ TEST_F(NotifierTest, 2Messages2Receivers_RestartReceivers_ExpectFeedback_VectorM
 }
 
 TEST_F(NotifierTest, 1Message1Receiver_ReceiveData) {
-   SEND_MSG_TYPE = MSG;
    TestThreadData senderData("sender");
    TestThreadData receiver1ThreadData("receiver");
    EXPECT_FALSE(FileIO::DoesFileExist(notifierQueuePath));


### PR DESCRIPTION
Like we discussed, the race condition in the test arose from the difference in time between when the Receiver notifies the parent that it has received something, and the time it takes the parent to understand this and shut the thread down. In the time gap, the while loop reruns, the ```ReceiveData``` call fails (there is nothing to receive now), and ultimately, the ```received``` variable was overwritten.

This will require the Research pull request to be tweaked.  